### PR TITLE
feat: 初回ルーレットでの固有職除外ルールの追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,7 +102,7 @@ async function startRoulette() {
 
   for (const char of chars) {
     const prevJobs = excludePrev ? getPreviousJobs(char.name, history) : [];
-    const pool = getAvailableJobs(char, { masteredJobs, excludePrev, excludeMastered, prevJobs });
+    const pool = getAvailableJobs(char, { masteredJobs, excludePrev, excludeMastered, prevJobs, historyLength: history.length });
     if (pool.length === 0) continue;
 
     const card = document.querySelector(`.character-card[data-character="${char.name}"]`);

--- a/logic.js
+++ b/logic.js
@@ -187,6 +187,7 @@ export function shouldExclude(jobName, prevJobs, masteredJobs, excludePrev, excl
  * @param {boolean} options.excludePrev - 直前の職を除外するか
  * @param {boolean} options.excludeMastered - マスター済みを除外するか
  * @param {string[]} options.prevJobs - 直前の職業名一覧
+ * @param {number} options.historyLength - 現在の履歴件数（0なら初回）
  * @returns {Array<{name: string, category: string}>}
  */
 export function getAvailableJobs(character, options) {
@@ -195,13 +196,15 @@ export function getAvailableJobs(character, options) {
     excludePrev = false,
     excludeMastered = false,
     prevJobs = [],
+    historyLength = 0,
   } = options;
 
   const charMastered = masteredJobs[character.name] || [];
   let jobs = [];
 
-  // 固有職
-  if (!shouldExclude(character.uniqueJob, prevJobs, charMastered, excludePrev, excludeMastered)) {
+  // 固有職（初回は除外）
+  if (historyLength > 0 &&
+    !shouldExclude(character.uniqueJob, prevJobs, charMastered, excludePrev, excludeMastered)) {
     jobs.push({ name: character.uniqueJob, category: 'unique' });
   }
 

--- a/logic.test.js
+++ b/logic.test.js
@@ -278,8 +278,21 @@ describe('shouldExclude', () => {
 describe('getAvailableJobs', () => {
   const hero = { name: '主人公', uniqueJob: 'ひよっこ漁師' };
 
+  it('初回（履歴なし） → 固有職は含まれない', () => {
+    const jobs = getAvailableJobs(hero, { masteredJobs: {}, historyLength: 0 });
+    const names = jobs.map(j => j.name);
+    expect(names).not.toContain('ひよっこ漁師');
+    expect(jobs.every(j => j.category !== 'unique')).toBe(true);
+  });
+
+  it('2回目以降 → 固有職が含まれる', () => {
+    const jobs = getAvailableJobs(hero, { masteredJobs: {}, historyLength: 1 });
+    const names = jobs.map(j => j.name);
+    expect(names).toContain('ひよっこ漁師');
+  });
+
   it('マスターなし → 基本職+固有職のみ（上級職なし）', () => {
-    const jobs = getAvailableJobs(hero, { masteredJobs: {} });
+    const jobs = getAvailableJobs(hero, { masteredJobs: {}, historyLength: 1 });
     const categories = [...new Set(jobs.map(j => j.category))];
     expect(categories).toContain('unique');
     expect(categories).toContain('basic');
@@ -289,7 +302,7 @@ describe('getAvailableJobs', () => {
 
   it('前提達成 → 上級職が候補に入る', () => {
     const mastered = { '主人公': ['戦士', '武闘家'] };
-    const jobs = getAvailableJobs(hero, { masteredJobs: mastered });
+    const jobs = getAvailableJobs(hero, { masteredJobs: mastered, historyLength: 1 });
     const advancedNames = jobs.filter(j => j.category === 'advanced').map(j => j.name);
     expect(advancedNames).toContain('バトルマスター');
     expect(advancedNames).not.toContain('賢者'); // 魔法使い+僧侶が未マスター
@@ -300,6 +313,7 @@ describe('getAvailableJobs', () => {
       masteredJobs: {},
       excludePrev: true,
       prevJobs: ['戦士', '僧侶'],
+      historyLength: 1,
     });
     const names = jobs.map(j => j.name);
     expect(names).not.toContain('戦士');
@@ -312,6 +326,7 @@ describe('getAvailableJobs', () => {
     const jobs = getAvailableJobs(hero, {
       masteredJobs: mastered,
       excludeMastered: true,
+      historyLength: 1,
     });
     const names = jobs.map(j => j.name);
     expect(names).not.toContain('戦士');
@@ -323,6 +338,7 @@ describe('getAvailableJobs', () => {
       masteredJobs: {},
       excludePrev: true,
       prevJobs: ['ひよっこ漁師'],
+      historyLength: 1,
     });
     const names = jobs.map(j => j.name);
     expect(names).not.toContain('ひよっこ漁師');


### PR DESCRIPTION
## 概要
- 初回（履歴なし）のルーレット実行時には、固有職が候補から除外されるように変更しました。
- 2回目以降のルーレットでは通常通り固有職も候補に含まれます。

## 変更点
- `logic.js`の`getAvailableJobs`に`historyLength`パラメータを追加し、0の場合は固有職を除外
- `app.js`から履歴のアレイ件数を渡すよう連携
- 初回除外および2回目以降の復帰テストをVitestに追加