### PR TITLE
fix: メイン・サブ両スロットから直前の職を明示的に除外する

### DIFF
--- a/app.js
+++ b/app.js
@@ -132,11 +132,11 @@ async function startCharacterRoulette(char) {
   card.classList.add('rolling');
   const slots = card.querySelectorAll('.job-slot');
 
-  const job1 = await animateSlot(slots[0], pool);
+  const job1 = await animateSlot(slots[0], pool, prevJobs);
   const charAssignment = { character: char.name, jobs: [{ ...job1, mastered: false }] };
 
   if (isDual && slots[1]) {
-    const job2 = await animateSlot(slots[1], pool, [job1.name]);
+    const job2 = await animateSlot(slots[1], pool, [...prevJobs, job1.name]);
     charAssignment.jobs.push({ ...job2, mastered: false });
   }
 

--- a/logic.test.js
+++ b/logic.test.js
@@ -420,6 +420,78 @@ describe('データ整合性', () => {
   });
 });
 
+// ── 掛け持ち時の直前職除外（メイン・サブ両方） ────────────────────
+
+describe('掛け持ち時の直前職除外', () => {
+  const hero = { name: '主人公', uniqueJob: 'ひよっこ漁師' };
+
+  it('直前のメイン職はプールに含まれない', () => {
+    const history = [{
+      assignments: [{
+        character: '主人公',
+        jobs: [
+          { name: '戦士', category: 'basic', mastered: false },
+          { name: '僧侶', category: 'basic', mastered: false },
+        ]
+      }]
+    }];
+    const prevJobs = getPreviousJobs('主人公', history);
+    const pool = getAvailableJobs(hero, {
+      masteredJobs: {},
+      excludePrev: true,
+      prevJobs,
+      historyLength: 1,
+    });
+    const names = pool.map(j => j.name);
+    expect(names).not.toContain('戦士'); // 直前のメイン職はメイン・サブ両スロットで選択不可
+    expect(names).not.toContain('僧侶'); // 直前のサブ職もメイン・サブ両スロットで選択不可
+  });
+
+  it('直前のサブ職もプールに含まれない', () => {
+    const history = [{
+      assignments: [{
+        character: '主人公',
+        jobs: [
+          { name: '魔法使い', category: 'basic', mastered: false },
+          { name: '踊り子', category: 'basic', mastered: false },
+        ]
+      }]
+    }];
+    const prevJobs = getPreviousJobs('主人公', history);
+    const pool = getAvailableJobs(hero, {
+      masteredJobs: {},
+      excludePrev: true,
+      prevJobs,
+      historyLength: 1,
+    });
+    const names = pool.map(j => j.name);
+    expect(names).not.toContain('魔法使い');
+    expect(names).not.toContain('踊り子');
+  });
+
+  it('プール内のすべての職が直前職でない', () => {
+    const history = [{
+      assignments: [{
+        character: '主人公',
+        jobs: [
+          { name: '戦士', category: 'basic', mastered: false },
+          { name: '僧侶', category: 'basic', mastered: false },
+        ]
+      }]
+    }];
+    const prevJobs = getPreviousJobs('主人公', history);
+    const pool = getAvailableJobs(hero, {
+      masteredJobs: {},
+      excludePrev: true,
+      prevJobs,
+      historyLength: 1,
+    });
+    pool.forEach(j => {
+      expect(prevJobs).not.toContain(j.name);
+    });
+  });
+});
+
 // ── getPreviousJobs - 部分的なキャラのみを含む履歴エントリ ────────
 
 describe('getPreviousJobs - 部分的なキャラのみを含む履歴エントリ', () => {


### PR DESCRIPTION
Fixes #7

直前の職（メイン・サブ両方）がメインスロット・サブスロットどちらからも選択されないよう、animateSlot の exclude パラメータに prevJobs を明示的に含めるよう修正。

Generated with [Claude Code](https://claude.ai/code)